### PR TITLE
Removes restriction on PowerShellHostVersion

### DIFF
--- a/Duo.psd1
+++ b/Duo.psd1
@@ -29,7 +29,7 @@ PowerShellVersion = '3.0'
 PowerShellHostName = ''
 
 # Minimum version of the Windows PowerShell host required by this module
-PowerShellHostVersion = '3.0'
+PowerShellHostVersion = ''
 
 # Minimum version of the .NET Framework required by this module
 DotNetFrameworkVersion = ''


### PR DESCRIPTION
Removes restriction on PowerShellHostVersion so that the module can run inside other hosts like VS Code.
This will allow debugging the module from within the PowerShell terminal in Visual Studio code, which runs PowerShell 5.1, but the $host version is only 1.2.1.

Name             : Visual Studio Code Host
Version          : 1.2.1
InstanceId       : a447ac91-e17d-4197-94e0-876e14268074
UI               : System.Management.Automation.Internal.Host.InternalHostUserInterface
CurrentCulture   : en-US
CurrentUICulture : en-US
PrivateData      :
DebuggerEnabled  : True
IsRunspacePushed : False
Runspace         : System.Management.Automation.Runspaces.LocalRunspace