### PR TITLE
Duo_org.ps1 doesn't load to the right scope

### DIFF
--- a/Duo.psd1
+++ b/Duo.psd1
@@ -56,7 +56,7 @@ ScriptsToProcess = @('Duo_org.ps1')
 #FormatsToProcess = @('')
 
 # Modules to import as nested modules of the module specified in ModuleToProcess
-NestedModules = @()
+NestedModules = @('Duo_org.ps1')
 
 # Functions to export from this module
 FunctionsToExport = 'Duo*'


### PR DESCRIPTION
When calling ```Import-Module Duo``` from another script, the Duo_org.ps1 script fails to load to the proper session scope.  You might be able to remove it from ScriptsToProcess, but I didn't want to break anything.  Adding it to NestedModules makes it work fine.